### PR TITLE
Switch benchmark site to Cloudflare Pages deployment

### DIFF
--- a/benchmark-site/astro.config.mjs
+++ b/benchmark-site/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://wangyihang.github.io',
-  base: '/ccupp',
+  site: 'https://ccupp.pages.dev',
 });


### PR DESCRIPTION
## Summary

- Remove GitHub Pages `base: '/ccupp'` from astro.config.mjs
- Set site URL to Cloudflare Pages domain

## Cloudflare Pages Setup

In CF Dashboard → Workers & Pages → Create → Pages → Connect to Git:

| Setting | Value |
|---------|-------|
| Root directory | `benchmark-site` |
| Build command | `npm install && npx astro build` |
| Output directory | `dist` |
| Environment: `NODE_VERSION` | `22` |

https://claude.ai/code/session_01ENy8KyUFrYfvEXsaFvFHtB